### PR TITLE
Sso config default and SSO control

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -338,6 +338,7 @@
 ## Controls whether users are allowed to login using SSO
 ## Set your Client ID and Client Key for SSO
 # SSO_ENABLED=true
+# SSO_ONLY=false
 # SSO_CLIENT_ID=11111
 # SSO_CLIENT_SECRET=AAAAAAAAAAAAAAAAAAAAAAAA
 # SSO_AUTHORITY=https://auth.example.com

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -299,7 +299,7 @@ async fn get_user_collections(headers: Headers, mut conn: DbConn) -> Json<Value>
 }
 
 #[get("/organizations/<_identifier>/auto-enroll-status")]
-async fn get_auto_enroll_status(_identifier: String) -> JsonResult {
+fn get_auto_enroll_status(_identifier: String) -> JsonResult {
     Ok(Json(json!({
         "ResetPasswordEnabled": false,
     })))
@@ -1479,7 +1479,7 @@ async fn list_policies_invited_user(org_id: String, userId: String, mut conn: Db
     if userId.is_empty() {
         err!("userId is empty.");
     }
-    
+
     let policies = OrgPolicy::find_by_org(&org_id, &mut conn).await;
     let policies_json: Vec<Value> = policies.iter().map(OrgPolicy::to_json).collect();
 

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -297,12 +297,8 @@ async fn _password_login(
         )
     }
 
-    // Check if org policy prevents password login
-    let user_orgs = UserOrganization::find_by_user_and_policy(&user.uuid, OrgPolicyType::RequireSso, conn).await;
-    if !user_orgs.is_empty() && user_orgs[0].atype != UserOrgType::Owner && user_orgs[0].atype != UserOrgType::Admin {
-        // if requires SSO is active, user is in exactly one org by policy rules
-        // policy only applies to "non-owner/non-admin" members
-        err!("Organization policy requires SSO sign in");
+    if CONFIG.sso_enabled() && CONFIG.sso_only() {
+        err!("SSO sign-in is required");
     }
 
     let now = Utc::now().naive_utc();

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -732,7 +732,6 @@ fn _check_is_some<T>(value: &Option<T>, msg: &str) -> EmptyResult {
     Ok(())
 }
 
-
 #[get("/account/prevalidate")]
 #[allow(non_snake_case)]
 fn prevalidate() -> JsonResult {

--- a/src/config.rs
+++ b/src/config.rs
@@ -585,15 +585,17 @@ make_config! {
     /// SSO settings
     sso {
         /// Enabled
-        sso_enabled:         bool,   true,   def,     true;
+        sso_enabled:            bool,   true,   def,    false;
+        /// Force SSO login
+        sso_only:               bool,   true,   def,    false;
         /// Client ID
-        sso_client_id:       String, true,   def,   String::new();
+        sso_client_id:          String, true,   def,    String::new();
         /// Client Key
-        sso_client_secret:      Pass,   true,  def,   String::new();
+        sso_client_secret:      Pass,   true,   def,    String::new();
         /// Authority Server
-        sso_authority:          String, true,   def,   String::new();
+        sso_authority:          String, true,   def,    String::new();
         /// CallBack Path
-        sso_callback_path:      String, false,   gen,  |c| generate_sso_callback_path(&c.domain);
+        sso_callback_path:      String, false,  gen,    |c| generate_sso_callback_path(&c.domain);
     },
 
     /// Yubikey settings

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -150,7 +150,7 @@ impl User {
     /// * `new_key` - A String  which contains the new aKey value of the users master password.
     /// * `allow_next_route` - A Option<Vec<String>> with the function names of the next allowed (rocket) routes.
     ///                       These routes are able to use the previous stamp id for the next 2 minutes.
-    ///                       After these 2 minutes this stamp will expire.f
+    ///                       After these 2 minutes this stamp will expire.
     ///
     pub fn set_password(
         &mut self,


### PR DESCRIPTION
Hey,

Forgot about the block which can disable password login, though the best option was to use an additional setting to let admin decide what he wants.

And In my previous PR had switch back the `sso_enabled` to `true` by default so it revert that too.

Added a fix to a random typo.