### PR TITLE
Improve IdP compatibility

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -236,7 +236,7 @@ async fn _authorization_login(
                     let mut result = json!({
                         "access_token": access_token,
                         "token_type": "Bearer",
-                        "refresh_token": refresh_token,
+                        "refresh_token": device.refresh_token,
                         "expires_in": expires_in,
                         "Key": user.akey,
                         "PrivateKey": user.private_key,
@@ -899,10 +899,9 @@ async fn get_auth_code_access_token(code: &str) -> Result<(String, String, CoreU
         Ok(client) => match client.exchange_code(oidc_code).request_async(async_http_client).await {
             Ok(token_response) => {
                 //let refresh_token = token_response.refresh_token():
-                let refresh_token: Option<String> = Some(token_response.refresh_token().unwrap().secret().to_string());
-                let refreshtoken = match refresh_token {
-                    Some(token) => token,
-                    None => String::new(),
+                let refreshtoken = match token_response.refresh_token() {
+                    Some(token) => token.secret().to_string(),
+                    None => String::new()
                 };
                 let id_token = token_response.extra_fields().id_token().unwrap().to_string();
 


### PR DESCRIPTION
Thanks so much for working on this!

I've noticed two problem when using your PR with the Shibboleth IdP:

- the response does not include a `refresh_token`. Your code tries to call `.unwrap()` on it and thus crashes. It also does not return the `device.refresh_token` automatically generated by `refresh_tokens()` but an empty string, causing the client to malfunction.
- `email` is not included in the `id_token` (it is [optional per the spec](https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims)), so it has to be fetched from the `userinfo` endpoint.

I've fixed both of these issues and would love for these additions to be included when the PR is eventually merged.

Cheers!

Cf. https://github.com/dani-garcia/vaultwarden/pull/3154